### PR TITLE
refactor: shorten invocation of dotenv

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,9 +1,7 @@
+require('dotenv').config();
 const basePath = process.cwd();
 const { ActivityType, Client, ChannelType, GatewayIntentBits, Partials, GuildExplicitContentFilter } = require('discord.js');
 const config = require(`${basePath}/src/config.json`);
-const dotenv = require('dotenv');
-
-dotenv.config();
 
 // discord bot tokens
 const { 


### PR DESCRIPTION
Since dotenv declaration isn't used in any part of the script, we can remove it to save memory and just shorten it to `require('dotenv).config()`